### PR TITLE
Removes extra empty variable while fetching cv2.findContours()

### DIFF
--- a/table_detection.py
+++ b/table_detection.py
@@ -24,7 +24,7 @@ def table_detection(img_path):
     table_segment = cv2.erode(cv2.bitwise_not(table_segment), kernel, iterations=2)
     thresh, table_segment = cv2.threshold(table_segment, 0, 255, cv2.THRESH_OTSU)
    
-    _, contours, hierarchy = cv2.findContours(table_segment, cv2.RETR_TREE, cv2.CHAIN_APPROX_SIMPLE)
+    contours, hierarchy = cv2.findContours(table_segment, cv2.RETR_TREE, cv2.CHAIN_APPROX_SIMPLE)
     count = 0
     for c in contours:
         x, y, w, h = cv2.boundingRect(c)


### PR DESCRIPTION
Ref: https://docs.opencv.org/3.4/d3/dc0/group__imgproc__shape.html#ga17ed9f5d79ae97bd4c7cf18403e1689a

 - Fixes #1 